### PR TITLE
Fix incorrect behaviour with arrays - adds index into brackets as side effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@ A straight forward gem to convert ruby hashes and arrays to http query strings f
     => "a[0]=bingo&a[1]=hepp"
 
     QueryParams.encode({a: [{b:'c', d:'e'}, {b:'g'}]})
-    => "a[][b]=c&a[][d]=e&a[][b]=g"
+    => "a[0][b]=c&a[0][d]=e&a[1][b]=g"

--- a/lib/queryparams.rb
+++ b/lib/queryparams.rb
@@ -5,11 +5,14 @@ module QueryParams
 
   def self.encode(value, key = nil)
     case value
-    when Hash  then value.map { |k,v| encode(v, append_key(key,k)) }.join('&')
-    when Array then value.map { |v| encode(v, "#{key}[]") }.join('&')
-    when nil   then ''
-    else            
-      "#{key}=#{CGI.escape(value.to_s)}" 
+    when Hash then value.map { |k,v| encode(v, append_key(key,k)) }.join('&')
+    when Array then 
+      values = []
+    	value.each_with_index { |v,i| puts "v => i"; values << encode(v, "#{key}[#{i}]") }
+    	values.join('&')
+    when nil then ''
+    else
+      "#{key}=#{CGI.escape(value.to_s)}"
     end
   end
 

--- a/spec/queryparams_spec.rb
+++ b/spec/queryparams_spec.rb
@@ -1,7 +1,7 @@
 require 'bundler'
 Bundler.require
 
-describe QueryParams do 
+describe QueryParams do
   it "generates nothing if need be" do
     QueryParams.encode({}).should eq ""
     QueryParams.encode(nil).should eq ""
@@ -16,10 +16,11 @@ describe QueryParams do
   end
 
   it "handles arrays" do
-    QueryParams.encode({a: ['bingo', 'hepp']}).should eq "a[]=bingo&a[]=hepp"
+    QueryParams.encode_with_index({a: ['bingo', 'hepp']}).should eq "a[0]=bingo&a[1]=hepp"
   end
 
   it "handles arrays of hashes" do
-    QueryParams.encode({a: [{b:'c', d:'e'}, {b:'g'}]}).should eq "a[][b]=c&a[][d]=e&a[][b]=g"
+    QueryParams.encode({a: [{b:'c', d:'e'}, {b:'g'}]}).should eq "a[0][b]=c&a[0][d]=e&a[1][b]=g"
   end
+
 end


### PR DESCRIPTION
Fix incorrect behaviour with arrays - adds index into brackets as side effect

QueryParams.encode({a: [{b:'c', d:'e'}, {b:'g'}]})
was giving  "a[][b]=c&a[][d]=e&a[][b]=g"
wich is interpreted as "a[0][b]=c&a[1][d]=e&a[2][b]=g"
that is to say {a: [{ b:'c' }, {d:'e'}, {b:'g'}]}

With the fix, the out put will be "a[0][b]=c&a[0][d]=e&a[1][b]=g"
which maps correctly back to {a: [{b:'c', d:'e'}, {b:'g'}]}
